### PR TITLE
feat: Add task creation functionality to project show page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,6 +8,7 @@ class ProjectsController < ApplicationController
   end
 
   def show
+    @task = Task.new
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 class TasksController < ApplicationController
+  before_action :set_project, only: :create
 
   def index
     @tasks = Task.all
@@ -14,10 +15,11 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
+    @task.project = @project
 
     if @task.save
       flash[:notice] = 'Task was successfully created.'
-      redirect_to tasks_path
+      redirect_to project_path(@project)
     else
       render :new
     end
@@ -46,7 +48,10 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :project_id)
+    params.require(:task).permit(:title, :start_date, :end_date)
   end
 
+  def set_project
+    @project = Project.find(params[:project_id])
+  end
 end

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -2,7 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
 
-  connect() {
-    console.log("Hello from toggle_controller.js")
+  static targets = [ "togglableElement" ]
+
+  toggleElement() {
+    this.togglableElementTarget.classList.toggle('d-none')
   }
 }

--- a/app/models/merit/point_rules.rb
+++ b/app/models/merit/point_rules.rb
@@ -18,6 +18,14 @@ module Merit
 
       # Updating a new project
       score 10, to: :user, on: 'tasks#create'
+
+      # Deleting a project
+      score -10, to: :user, on: 'projects#destroy'
+
+      # Creating a new task
+      score 1, to: :user, on: 'tasks#create'
+
+
     end
   end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -8,23 +8,28 @@
   <h2>Tasks:</h2>
   <ul>
     <% @project.tasks.each do |task| %>
-      <li><%= task.name %></li>
+      <li><%= task.title %> | <%= task.start_date%> - <%= task.end_date %></li>
     <% end %>
   </ul>
 <% else %>
   <p>No tasks found for this project.</p>
 <% end %>
 
-<div data-toggle-target="togglableElement" class="d-none">
-  <%= simple_form_for([@project, @task]) do |f| %>
-    <%= f.input :title %>
-    <%= f.input :start_date %>
-    <%= f.input :end_date %>
-    <%= f.button :submit, 'Create Task' %>
-  <% end %>
-</div>
 
 
 <%= link_to 'Edit', edit_project_path(@project) %> |
 <%= link_to 'Back', projects_path %>
-<%= link_to 'Add Task', new_project_tasks_path(current_user, @project) %>
+
+<div data-controller="toggle">
+  <button data-action="click->toggle#toggleElement">Add task</button>
+
+  <div data-toggle-target="togglableElement" class="d-none">
+    <%= simple_form_for([@project, @task]) do |f| %>
+      <%= f.input :title %>
+      <%= f.input :start_date %>
+      <%= f.input :end_date %>
+      <%= f.button :submit, 'Create Task' %>
+    <% end %>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   end
 
   resources :projects do
-    resources :tasks, only: [:show, :new, :edit, :update, :destroy]
+    resources :tasks, only: [:show, :new, :create, :edit, :update, :destroy]
     get 'calendar', to: 'projects#calendar', as: :calendar, on: :member
   end
 


### PR DESCRIPTION
This commit adds the functionality to create tasks directly from the project show page. A new task form is displayed when the "Add task" button is clicked, allowing users to enter the task title, start date, and end date. The task is then associated with the project and saved to the database.